### PR TITLE
bump http-cache-semantics from 4.1.0 to 4.1.1

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6579,9 +6579,9 @@ fsevents@^2.3.2:
   linkType: hard
 
 "http-cache-semantics@npm:^4.0.0, http-cache-semantics@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "http-cache-semantics@npm:4.1.0"
-  checksum: 974de94a81c5474be07f269f9fd8383e92ebb5a448208223bfb39e172a9dbc26feff250192ecc23b9593b3f92098e010406b0f24bd4d588d631f80214648ed42
+  version: 4.1.1
+  resolution: "http-cache-semantics@npm:4.1.1"
+  checksum: 83ac0bc60b17a3a36f9953e7be55e5c8f41acc61b22583060e8dedc9dd5e3607c823a88d0926f9150e571f90946835c7fe150732801010845c72cd8bbff1a236
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
---
updated-dependencies:
- dependency-name: http-cache-semantics dependency-type: indirect ...